### PR TITLE
Updating logic in Invoke-xSConfig to target new SConfig module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updating logic in Invoke-xSConfig to target new SConfig module #9
+
 ## [0.1.3]
 
 ### Added

--- a/Tests/Invoke-xSConfig.test.ps1
+++ b/Tests/Invoke-xSConfig.test.ps1
@@ -1,0 +1,11 @@
+InModuleScope xSConfig {
+    Describe "Invoke-xSConfig" {
+        Context 'Desktop Experience Node' {
+            It "Should error when SConfig isn't present"{
+                Invoke-xSConfig | Should -throw
+            }
+        }
+        Context 'Server Core Node' -skip {
+        }
+    }
+}

--- a/src/Public/Invoke-xSConfig.ps1
+++ b/src/Public/Invoke-xSConfig.ps1
@@ -2,12 +2,13 @@ function Invoke-xSConfig {
     [cmdletbinding()]
     param()
     begin {
-        If (-not (Get-Module SConfig -ListAvailable)) {
+	$SConfigModule = Get-Module -ListAvailable -Name *Sconfig | Where-object {$_.Name -ne 'xSConfig'}
+        If ($null -eq $SConfigModule) {
             Throw "'SConfig' Module is missing. xSconfig cannot be used without it."
         }
         else {
-            Import-Module SConfig
-            $Module = Get-Module SConfig
+            Import-Module $SConfigModule.Name
+            $Module = Get-Module $SConfigModule.Name
         }
     }
     process {
@@ -18,7 +19,7 @@ function Invoke-xSConfig {
             } # IF
             
             # Update Menu Items
-            $MenuItemsScriptBlock = Get-Command -Name Get-MenuItems -Module SConfig | Select-Object -ExpandProperty ScriptBlock
+            $MenuItemsScriptBlock = Get-Command -Name Get-MenuItems -Module $SConfigModule.Name | Select-Object -ExpandProperty ScriptBlock
             $AdditionalMenuItems = @"
     16) Extras
 
@@ -32,7 +33,7 @@ function Invoke-xSConfig {
     
             Invoke-Expression -Command $UpdatedMenuItems
 
-            $SconfigScriptblock = Get-Command -Name Invoke-SConfig -Module SConfig | Select-Object -ExpandProperty ScriptBlock
+            $SconfigScriptblock = Get-Command -Name Invoke-SConfig -Module $SConfigModule.Name | Select-Object -ExpandProperty ScriptBlock
             $UpdatedSconfigScriptblock = $SconfigScriptblock -replace '(switch \(Get\-MenuSelection\) \{)','$1
             "16" { Invoke-ExtrasMenu } '
             Invoke-Expression -Command $UpdatedSconfigScriptblock


### PR DESCRIPTION
Closes issue #9 

Rather than hardcoding the `SConfig` module name, we now look for any `*SConfig` module excluding `xSConfig` explicitly.

This should be more future proof